### PR TITLE
Fix unresponsive Sign In button due to JavaScript naming conflict

### DIFF
--- a/index.html
+++ b/index.html
@@ -2137,7 +2137,7 @@
         const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN5a2pqcnJleGFxbXNxd3JnbnpwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTE2MjUyMDksImV4cCI6MjA2NzIwMTIwOX0.Fx6f23TWCQQMCIkc5hcx8LqHyskVMm6WAhJl1UFZpMA';
 
         // Initialize Supabase
-        const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+        const supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
         // Authentication Functions
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
The sign-in button was unresponsive because of a JavaScript syntax error. The code attempted to declare a `const supabase` which conflicted with the global `supabase` object initialized by the Supabase CDN library. This fatal error prevented all subsequent scripts, including the login event listeners, from being attached.

I have renamed the local variable to `supabaseClient` to resolve the conflict. Verification with Playwright confirmed that the error is gone and users can now successfully sign in to reach the dashboard.

---
*PR created automatically by Jules for task [12164946508677529734](https://jules.google.com/task/12164946508677529734) started by @AhmetNasan*

## Summary by Sourcery

Bug Fixes:
- Fix unresponsive sign-in button by renaming the local Supabase client variable to avoid collisions with the global Supabase object.