### PR TITLE
🎨 Palette: Improve accessibility of sidebar and header buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Accessibility Refactoring with Visual Parity
+**Learning:** In single-file HTML applications with custom CSS, refactoring non-semantic interactive `div` elements to `<button>` for keyboard accessibility requires a specific CSS reset (border, background, font, text-align, width) to avoid breaking the layout while gaining a11y benefits.
+**Action:** Always include a CSS reset for `<button>` elements when replacing `div` click handlers to ensure they maintain the original design's visual weight and alignment.

--- a/index.html
+++ b/index.html
@@ -340,6 +340,11 @@
             transition: var(--transition);
             color: var(--text-light);
             text-decoration: none;
+            border: none;
+            background: transparent;
+            font: inherit;
+            text-align: left;
+            width: 100%;
         }
 
         .nav-item:hover,
@@ -1046,13 +1051,13 @@
         <!-- Header -->
         <header class="header">
             <div class="header-left">
-                <button class="sidebar-toggle" onclick="toggleSidebar()">
+                <button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Toggle sidebar">
                     <i class="fas fa-bars"></i>
                 </button>
                 <div class="logo">Engineering Platform</div>
             </div>
             <div class="header-actions">
-                <button class="theme-toggle" onclick="toggleTheme()">
+                <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
                     <i class="fas fa-moon"></i>
                 </button>
                 <div class="user-menu">
@@ -1079,86 +1084,86 @@
             <nav id="sidebar" class="sidebar">
                 <div class="nav-section">
                     <div class="nav-section-title">Main</div>
-                    <div class="nav-item active" onclick="showPage('dashboard')">
+                    <button class="nav-item active" onclick="showPage('dashboard')">
                         <i class="fas fa-tachometer-alt"></i> Dashboard
-                    </div>
-                    <div class="nav-item" onclick="showPage('projects')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('projects')">
                         <i class="fas fa-project-diagram"></i> Projects
-                    </div>
-                    <div class="nav-item" onclick="showPage('notifications')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('notifications')">
                         <i class="fas fa-bell"></i> Notifications
-                    </div>
+                    </button>
                 </div>
 
                 <div class="nav-section">
                     <div class="nav-section-title">Project Management</div>
-                    <div class="nav-item" onclick="showPage('contracts')">
+                    <button class="nav-item" onclick="showPage('contracts')">
                         <i class="fas fa-file-contract"></i> Contracts & BOQ
-                    </div>
-                    <div class="nav-item" onclick="showPage('inspection')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('inspection')">
                         <i class="fas fa-clipboard-check"></i> Inspection Reports
-                    </div>
-                    <div class="nav-item" onclick="showPage('cost-estimation')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('cost-estimation')">
                         <i class="fas fa-calculator"></i> Cost Estimation
-                    </div>
-                    <div class="nav-item" onclick="showPage('timeline')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('timeline')">
                         <i class="fas fa-timeline"></i> Project Timeline
-                    </div>
+                    </button>
                 </div>
 
                 <div class="nav-section">
                     <div class="nav-section-title">Engineering Tools</div>
-                    <div class="nav-item" onclick="showPage('map')">
+                    <button class="nav-item" onclick="showPage('map')">
                         <i class="fas fa-map-marked-alt"></i> GIS Mapping
-                    </div>
-                    <div class="nav-item" onclick="showPage('drawing')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('drawing')">
                         <i class="fas fa-drafting-compass"></i> CAD Drawing
-                    </div>
-                    <div class="nav-item" onclick="showPage('ai-defect')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('ai-defect')">
                         <i class="fas fa-robot"></i> AI Defect Analysis
-                    </div>
-                    <div class="nav-item" onclick="showPage('notebooks')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('notebooks')">
                         <i class="fas fa-book"></i> Notebooks
-                    </div>
+                    </button>
                 </div>
 
                 <div class="nav-section">
                     <div class="nav-section-title">Operations</div>
-                    <div class="nav-item" onclick="showPage('vehicle-tracking')">
+                    <button class="nav-item" onclick="showPage('vehicle-tracking')">
                         <i class="fas fa-truck"></i> Vehicle Tracking
-                    </div>
-                    <div class="nav-item" onclick="showPage('material-logistics')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('material-logistics')">
                         <i class="fas fa-boxes"></i> Material Logistics
-                    </div>
-                    <div class="nav-item" onclick="showPage('sign-fabrication')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('sign-fabrication')">
                         <i class="fas fa-sign"></i> Sign Fabrication
-                    </div>
-                    <div class="nav-item" onclick="showPage('scrap-management')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('scrap-management')">
                         <i class="fas fa-recycle"></i> Scrap Management
-                    </div>
+                    </button>
                 </div>
 
                 <div class="nav-section">
                     <div class="nav-section-title">Communication</div>
-                    <div class="nav-item" onclick="showPage('chat')">
+                    <button class="nav-item" onclick="showPage('chat')">
                         <i class="fas fa-comments"></i> Team Chat
-                    </div>
-                    <div class="nav-item" onclick="showPage('telegram')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('telegram')">
                         <i class="fab fa-telegram"></i> Telegram Integration
-                    </div>
-                    <div class="nav-item" onclick="showPage('reports')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('reports')">
                         <i class="fas fa-chart-bar"></i> Custom Reports
-                    </div>
+                    </button>
                 </div>
 
                 <div class="nav-section">
                     <div class="nav-section-title">System</div>
-                    <div class="nav-item" onclick="showPage('file-manager')">
+                    <button class="nav-item" onclick="showPage('file-manager')">
                         <i class="fas fa-folder"></i> File Manager
-                    </div>
-                    <div class="nav-item" onclick="showPage('settings')">
+                    </button>
+                    <button class="nav-item" onclick="showPage('settings')">
                         <i class="fas fa-cog"></i> Settings
-                    </div>
+                    </button>
                 </div>
             </nav>
 


### PR DESCRIPTION
Improved accessibility by refactoring non-semantic navigation divs to buttons and adding ARIA labels to icon-only buttons. Added CSS resets to ensure visual parity. Verified changes with Playwright.

---
*PR created automatically by Jules for task [13021747794483502668](https://jules.google.com/task/13021747794483502668) started by @AhmetNasan*

## Summary by Sourcery

Improve accessibility of the navigation sidebar and header controls while preserving the existing visual design.

New Features:
- Make sidebar navigation items proper buttons for keyboard and assistive technology interaction.

Enhancements:
- Add ARIA labels to icon-only header buttons for better screen reader support.
- Apply button CSS resets so converted navigation buttons visually match the previous div-based layout.
- Document accessibility learnings and best practices for refactoring interactive divs to buttons in the palette notes.