### PR TITLE
🎨 Palette: Improve table row selection visibility and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Table Row Selection Visibility]
+**Learning:** Adding visual feedback for selected rows in large data tables significantly improves user orientation, especially when interactive features (like clipboard pasting) depend on the selection state.
+**Action:** Always ensure `.selected` classes have corresponding CSS rules and ARIA attributes (`aria-selected`).

--- a/index.html
+++ b/index.html
@@ -208,6 +208,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:100;background:var(--surface);ba
 .main-table thead th{background:var(--surface2);padding:10px 12px;text-align:left;font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);white-space:nowrap;border-bottom:1px solid var(--border);position:sticky;top:0;}
 .main-table tbody tr{border-bottom:1px solid var(--border);transition:background .15s;}
 .main-table tbody tr:hover{background:rgba(255,255,255,.03);}
+.main-table tbody tr.selected { background: rgba(0, 200, 255, 0.1); }
 .main-table tbody td{padding:9px 12px;vertical-align:middle;white-space:nowrap;}
 .wo-num{font-family:'Inter', 'Noto Sans Arabic', sans-serif;font-weight:700;font-size:13px;color:var(--accent);}
 .desc-cell{max-width:200px;overflow:hidden;text-overflow:ellipsis;color:var(--text);}
@@ -1975,8 +1976,13 @@ function applyFilters() {
 function selectWorkOrderRow(woId) {
   selectedWorkOrder = woId;
   document.querySelectorAll('#woBody tr').forEach(tr => {
-    if (tr.getAttribute('data-wo') === woId) tr.classList.add('selected');
-    else tr.classList.remove('selected');
+    if (tr.getAttribute('data-wo') === woId) {
+      tr.classList.add('selected');
+      tr.setAttribute('aria-selected', 'true');
+    } else {
+      tr.classList.remove('selected');
+      tr.removeAttribute('aria-selected');
+    }
   });
 }
 
@@ -2013,7 +2019,7 @@ function renderTable() {
       <button class="btn btn-ghost btn-sm" onclick="event.stopPropagation(); copyCoords(${r.Lat}, ${r.Lng})" title="Copy Coordinates"><i class="fas fa-copy"></i></button>
     ` : '';
 
-    return `<tr class="${isSelected ? 'selected' : ''}" data-wo="${r.WorkOrder}" onclick="selectWorkOrderRow('${r.WorkOrder}')">
+    return `<tr class="${isSelected ? 'selected' : ''}" data-wo="${r.WorkOrder}" onclick="selectWorkOrderRow('${r.WorkOrder}')" ${isSelected ? 'aria-selected="true"' : ''}>
       <td style="color:var(--muted);font-size:11px">${start+i+1}</td>
       <td onclick="makeEditable(this, '${r.WorkOrder}', 'WorkOrder')"><span class="wo-num">${r.WorkOrder}</span></td>
       <td class="desc-cell" title="${(r.Description||'').replace(/"/g,"'")}" onclick="makeEditable(this, '${r.WorkOrder}', 'Description')"><span>${(r.Description||'').substring(0,40)}</span></td>


### PR DESCRIPTION
💡 **What**: Improved the user experience for selecting rows in the Work Order table.
🎯 **Why**: Previously, clicking a row would "select" it for features like clipboard image pasting, but there was no visual indication of which row was active. This caused user confusion and orientation issues in large datasets.
📸 **Before/After**: Rows now highlight with a light blue background when selected.
♿ **Accessibility**: Added `aria-selected` attributes to table rows to ensure the selection state is perceivable by assistive technologies.

---
*PR created automatically by Jules for task [15323353624346653562](https://jules.google.com/task/15323353624346653562) started by @AhmetNasan*

## Summary by Sourcery

Improve visibility and accessibility of selected rows in the Work Order table.

New Features:
- Add visual highlighting for selected table rows in the Work Order list.

Enhancements:
- Track row selection state with a dedicated CSS class and ARIA attributes for better accessibility.

Documentation:
- Document the pattern for table row selection styling and ARIA usage in the Palette notes.