### PR TITLE
🎨 Palette: Add 'Enter' key support for auth forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Enter Key Support for Forms]
+**Learning:** Users instinctively expect the 'Enter' key to submit forms, especially in authentication and modal contexts. In monolithic HTML applications lacking native `<form>` structures, explicit keyboard event handlers are necessary to meet this expectation and improve accessibility.
+**Action:** Always check if primary input fields in modals or auth cards have keyboard submission support, and implement `onkeydown` handlers if native form submission is not utilized.

--- a/index.html
+++ b/index.html
@@ -713,13 +713,13 @@ nav{position:fixed;top:0;left:0;right:0;z-index:100;background:var(--surface);ba
     <p id="auth-subtitle" style="font-size: 12px; color: var(--muted); margin-bottom: 24px;">Sign in to Qatar Building Company platform</p>
     
     <div id="signup-fields" style="display: none;">
-      <input type="text" id="auth-fullname" class="auth-input" placeholder="Full Name">
-      <input type="text" id="auth-mobile" class="auth-input" placeholder="Mobile Number">
-      <input type="text" id="auth-position" class="auth-input" placeholder="Position / Job Title">
+      <input type="text" id="auth-fullname" class="auth-input" placeholder="Full Name" onkeydown="if(event.key==='Enter')handleAuth()">
+      <input type="text" id="auth-mobile" class="auth-input" placeholder="Mobile Number" onkeydown="if(event.key==='Enter')handleAuth()">
+      <input type="text" id="auth-position" class="auth-input" placeholder="Position / Job Title" onkeydown="if(event.key==='Enter')handleAuth()">
     </div>
 
-    <input type="email" id="auth-email" class="auth-input" placeholder="Email Address">
-    <input type="password" id="auth-password" class="auth-input" placeholder="Password">
+    <input type="email" id="auth-email" class="auth-input" placeholder="Email Address" onkeydown="if(event.key==='Enter')handleAuth()">
+    <input type="password" id="auth-password" class="auth-input" placeholder="Password" onkeydown="if(event.key==='Enter')handleAuth()">
     
     <button class="auth-btn" id="auth-submit-btn" onclick="handleAuth()">Sign In</button>
     <div style="margin-top: 16px; font-size: 11px; color: var(--accent); cursor: pointer;" onclick="openModal('recoveryModal')">Forgot Password?</div>
@@ -1032,7 +1032,7 @@ nav{position:fixed;top:0;left:0;right:0;z-index:100;background:var(--surface);ba
     <p style="font-size:12px; color:var(--muted); margin-bottom:20px;">Please enter your email address. We will send you a link to reset your password.</p>
     <div class="form-group">
       <label>Email Address</label>
-      <input type="email" id="recovery-email" class="auth-input" placeholder="Enter your email">
+      <input type="email" id="recovery-email" class="auth-input" placeholder="Enter your email" onkeydown="if(event.key==='Enter')submitRecovery()">
     </div>
     <div class="modal-footer">
       <button class="btn btn-ghost btn-sm" onclick="closeModal('recoveryModal')">Cancel</button>


### PR DESCRIPTION
Implemented 'Enter' key submission support for all authentication and password recovery input fields in `index.html`. This enhances usability and accessibility for keyboard-centric users by aligning with standard web form behavior.

---
*PR created automatically by Jules for task [12361572048087234916](https://jules.google.com/task/12361572048087234916) started by @AhmetNasan*

## Summary by Sourcery

Add keyboard 'Enter' key submission support to authentication and password recovery inputs and document the UX learning in the Palette notes.

Enhancements:
- Enable all auth signup, login, and password recovery inputs to trigger their respective submission handlers when pressing the 'Enter' key.

Documentation:
- Add a Palette note documenting the UX learning and best practice for ensuring keyboard submission support in forms without native form elements.