### PR TITLE
🎨 Palette: Improve topbar and sidebar accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Improving topbar and sidebar accessibility]
+**Learning:** Icon-only buttons and interactive `div` elements are common in this app. Converting these to semantic `<button>` elements with `aria-label` significantly improves keyboard navigation and screen reader support without affecting the visual design, thanks to utility classes like `.btn-reset`.
+**Action:** Always check for `onclick` handlers on non-interactive elements (like `div`) and convert them to `<button>` with appropriate ARIA attributes.

--- a/index.html
+++ b/index.html
@@ -1171,23 +1171,23 @@ body {
 <!-- SIDEBAR -->
 <aside class="sidebar" id="sidebar" style="display: none;">
   <div class="sidebar-logo">Q</div>
-  <button class="sidebar-icon active" onclick="showPage('dashboard')" title="Dashboard" id="nav-icon-dashboard">
+  <button class="sidebar-icon active" onclick="showPage('dashboard')" title="Dashboard" id="nav-icon-dashboard" aria-label="Dashboard">
     <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
   </button>
-  <button class="sidebar-icon" onclick="showPage('workorders')" title="Work Orders" id="nav-icon-workorders">
+  <button class="sidebar-icon" onclick="showPage('workorders')" title="Work Orders" id="nav-icon-workorders" aria-label="Work Orders">
     <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
   </button>
-  <button class="sidebar-icon" onclick="showPage('manufacturing')" title="Manufacturing" id="nav-icon-manufacturing">
+  <button class="sidebar-icon" onclick="showPage('manufacturing')" title="Manufacturing" id="nav-icon-manufacturing" aria-label="Manufacturing">
     <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M2 20V4a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v16"/><path d="M7 10h10"/><path d="M7 14h10"/><path d="M7 18h10"/></svg>
   </button>
-  <button class="sidebar-icon" onclick="showPage('map')" title="GIS Mapping" id="nav-icon-map">
+  <button class="sidebar-icon" onclick="showPage('map')" title="GIS Mapping" id="nav-icon-map" aria-label="GIS Mapping">
     <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg>
   </button>
-  <button class="sidebar-icon" onclick="showPage('filemanager')" title="File Manager" id="nav-icon-filemanager">
+  <button class="sidebar-icon" onclick="showPage('filemanager')" title="File Manager" id="nav-icon-filemanager" aria-label="File Manager">
     <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
   </button>
   <div class="sidebar-spacer"></div>
-  <button class="sidebar-icon" onclick="showPage('settings')" title="Settings" id="nav-icon-settings" style="display: none;">
+  <button class="sidebar-icon" onclick="showPage('settings')" title="Settings" id="nav-icon-settings" style="display: none;" aria-label="Settings">
     <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06-.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
   </button>
 </aside>
@@ -1207,18 +1207,20 @@ body {
     <div class="topbar-spacer"></div>
     <div class="topbar-search">
       <svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-      <input type="text" id="global-search-input" placeholder="Search records, locations..." onkeydown="if(event.key==='Enter')handleGlobalSearch()">
+      <input type="text" id="global-search-input" placeholder="Search records, locations..." onkeydown="if(event.key==='Enter')handleGlobalSearch()" aria-label="Global search">
     </div>
-    <div class="topbar-alerts" onclick="toggleNotifPanel()" title="Notifications">
+    <button class="topbar-alerts btn-reset" onclick="toggleNotifPanel()" title="Notifications" aria-label="Notifications">
       <div class="alert-dot" id="notif-dot" style="display: none;"></div>
       <svg width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/></svg>
-    </div>
-    <div class="topbar-user" id="nav-user-btn" onclick="toggleUserDropdown()">
-      <div class="user-avatar" id="nav-user-initial">U</div>
-      <div class="user-info">
-        <div class="name" id="nav-user-name">Ops team</div>
-        <div class="live-badge" id="conn-status" style="margin-top: 2px;"><div class="live-dot" id="conn-dot"></div> <span id="conn-text">Live sync</span></div>
-      </div>
+    </button>
+    <div class="topbar-user" id="nav-user-wrapper" style="position: relative; display: flex; align-items: center;">
+      <button class="btn-reset" id="nav-user-btn" onclick="toggleUserDropdown()" aria-label="User menu" aria-haspopup="true" aria-expanded="false" style="display: flex; align-items: center; gap: 8px; background: var(--glow-blue); border: 1px solid rgba(59,130,246,0.1); border-radius: 8px; padding: 4px 10px; font-size: 12px; cursor: pointer;">
+        <div class="user-avatar" id="nav-user-initial">U</div>
+        <div class="user-info">
+          <div class="name" id="nav-user-name">Ops team</div>
+          <div class="live-badge" id="conn-status" style="margin-top: 2px;"><div class="live-dot" id="conn-dot"></div> <span id="conn-text">Live sync</span></div>
+        </div>
+      </button>
       <div class="user-dropdown" id="user-dropdown" role="menu">
         <button class="dropdown-item" onclick="showProfile()" role="menuitem"><i class="fas fa-user-circle"></i> Profile</button>
         <button class="dropdown-item" onclick="showPage('settings')" role="menuitem"><i class="fas fa-sliders-h"></i> Settings</button>
@@ -1233,7 +1235,7 @@ body {
 <div id="notif-panel" class="notif-panel">
   <div class="notif-header">
     <div class="notif-title">Notifications</div>
-    <button class="btn-reset" onclick="toggleNotifPanel()"><i class="fas fa-times"></i></button>
+    <button class="btn-reset" onclick="toggleNotifPanel()" aria-label="Close notification panel"><i class="fas fa-times"></i></button>
   </div>
   <div class="notif-tabs">
     <button class="notif-tab active" onclick="switchNotifTab('all')">All</button>
@@ -1586,8 +1588,8 @@ body {
       <button class="btn btn-ghost btn-sm" onclick="toggleGisSidebar()" title="Toggle Sidebar"><i class="fas fa-bars"></i></button>
       <div class="gis-search-wrap" style="flex: 1; max-width: 600px; display: flex; align-items: center; background: var(--surface2); border-radius: 8px; padding: 0 12px; border: 1px solid var(--border);">
         <i class="fas fa-search" style="color:var(--muted)"></i>
-        <input type="text" id="map-search-input" class="gis-search-input" placeholder="Search Asset ID, coordinates, or locations..." onkeydown="if(event.key==='Enter')searchCoordinates()" style="background: transparent; border: none; color: var(--text); flex: 1; padding: 8px; outline: none; font-size: 13px;">
-        <button class="btn-reset" onclick="searchCoordinates()"><i class="fas fa-arrow-right" style="color:var(--accent)"></i></button>
+        <input type="text" id="map-search-input" class="gis-search-input" placeholder="Search Asset ID, coordinates, or locations..." onkeydown="if(event.key==='Enter')searchCoordinates()" style="background: transparent; border: none; color: var(--text); flex: 1; padding: 8px; outline: none; font-size: 13px;" aria-label="GIS search">
+        <button class="btn-reset" onclick="searchCoordinates()" aria-label="Search coordinates"><i class="fas fa-arrow-right" style="color:var(--accent)"></i></button>
       </div>
       <div style="flex: 1;"></div>
       <div class="gis-top-actions">


### PR DESCRIPTION
### 💡 What
This PR improves the accessibility and semantic structure of the engineering platform's topbar and sidebar. Key changes include:
- Adding `aria-label` attributes to all icon-only buttons (sidebar, search, notifications, close buttons).
- Converting interactive `div` elements (`.topbar-alerts` and `#nav-user-btn`) into semantic `<button>` elements.
- Restructuring the user menu trigger and dropdown to ensure valid HTML (no nested interactive elements).

### 🎯 Why
The interface previously relied on non-semantic `div` elements and icon-only buttons without descriptive labels, making it difficult for screen reader users to navigate. Nested interactive elements in the user menu were also causing invalid DOM structures.

### 📸 Before/After
- **Before:** Topbar elements were `div`s; sidebar icons had only `title` attributes.
- **After:** Topbar elements are focusable `button`s; all icons have descriptive `aria-label`s. Visual appearance remains identical thanks to the `.btn-reset` utility class.

### ♿ Accessibility
- Improved screen reader support with descriptive labels.
- Enhanced keyboard navigation by using semantic interactive elements.
- Fixed invalid HTML nesting for better accessibility tree consistency.

---
*PR created automatically by Jules for task [11141348792245917200](https://jules.google.com/task/11141348792245917200) started by @AhmetNasan*

## Summary by Sourcery

Improve accessibility and semantics of the topbar and sidebar navigation.

New Features:
- Add descriptive aria-labels to sidebar navigation buttons and search inputs for better screen reader support.

Enhancements:
- Convert notification trigger and user menu trigger from generic divs to semantic buttons and adjust user dropdown structure to avoid nested interactive elements.
- Add aria-labels to icon-only buttons such as notifications, close notification panel, and GIS search trigger to align with accessibility best practices.
- Document accessibility learnings and guidelines for interactive elements in a new palette note under .Jules/palette.md.