### PR TITLE
🎨 Palette: Improve Follow-Up Center accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,6 +327,10 @@
   background: var(--color-accent-teal);
   color: var(--color-text-inverse);
 }
+.fuc-view-btn:focus-visible {
+  outline: 2px solid var(--color-accent-teal);
+  outline-offset: 2px;
+}
 
 .fuc-fab {
   position: fixed; bottom: 28px; right: 28px; z-index: 8000;
@@ -339,6 +343,10 @@
   transition: all var(--transition-normal);
 }
 .fuc-fab:hover { transform: scale(1.1) rotate(45deg); }
+.fuc-fab:focus-visible {
+  outline: 2px solid var(--color-accent-teal);
+  outline-offset: 2px;
+}
 .fuc-fab-menu {
   position: fixed; bottom: 90px; right: 28px; z-index: 8000;
   display: none; flex-direction: column; gap: var(--space-2);
@@ -2818,8 +2826,8 @@ nav{position:fixed;top:0;left:0;right:0;z-index:100;background:var(--surface);ba
         <button class="btn btn-ghost btn-sm" onclick="exportFUCPDF()"><i class="fas fa-file-pdf"></i> Export</button>
         
         <div class="fuc-view-toggle">
-          <button class="fuc-view-btn active" id="fuc-view-board" onclick="setFUCView('board')" title="Board View"><i class="fas fa-columns"></i></button>
-          <button class="fuc-view-btn" id="fuc-view-list" onclick="setFUCView('list')" title="List View"><i class="fas fa-list"></i></button>
+          <button class="fuc-view-btn active" id="fuc-view-board" onclick="setFUCView('board')" title="Board View" aria-label="Board View"><i class="fas fa-columns"></i></button>
+          <button class="fuc-view-btn" id="fuc-view-list" onclick="setFUCView('list')" title="List View" aria-label="List View"><i class="fas fa-list"></i></button>
         </div>
       </div>
 
@@ -13313,7 +13321,7 @@ async function refreshUI() {
 </div>
 
 <!-- FUC FAB -->
-<button class="fuc-fab" id="fuc-fab" style="display:none;" onclick="toggleFUCFabMenu()" title="Add New">
+<button class="fuc-fab" id="fuc-fab" style="display:none;" onclick="toggleFUCFabMenu()" title="Add New" aria-label="Add new note or reminder">
   <i class="fas fa-plus"></i>
 </button>
 <div class="fuc-fab-menu" id="fuc-fab-menu">


### PR DESCRIPTION
This PR introduces micro-UX improvements to the Follow-Up Center in `index.html`. 

### 💡 What
- Added `aria-label` attributes to the Board View, List View, and Floating Action Button (FAB).
- Added explicit `:focus-visible` CSS rules for these buttons to ensure a clear visual indicator for keyboard users.

### 🎯 Why
Icon-only buttons are inaccessible to screen reader users without proper labels. Additionally, keyboard users need clear focus indicators to navigate efficiently and understand which element is active.

### ♿ Accessibility
- Improved screen reader support for key interaction points.
- Enhanced keyboard navigability with high-contrast focus rings.
- Follows the project's accessibility standards by using existing design tokens.

---
*PR created automatically by Jules for task [3820208090086151640](https://jules.google.com/task/3820208090086151640) started by @AhmetNasan*

## Summary by Sourcery

Improve accessibility of the Follow-Up Center view toggle and floating action button.

Enhancements:
- Add ARIA labels to the Follow-Up Center Board View, List View, and floating action button to improve screen reader accessibility.
- Introduce explicit focus-visible outlines for Follow-Up Center view toggle buttons and floating action button to enhance keyboard focus visibility.