### PR TITLE
🎨 Palette: Follow-Up Center Accessibility & Micro-UX Enhancements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Accessible Color Swatches Pattern]
+**Learning:** In this vanilla JS environment, interactive elements often use `div` with `onclick`. These are invisible to screen readers and keyboard users.
+**Action:** Always apply `role="button"`, `tabindex="0"`, and `aria-label` to these elements, and bridge the gap with a global `keydown` listener in `setupFUCListeners` to map 'Enter'/'Space' to `click()`.

--- a/index.html
+++ b/index.html
@@ -347,6 +347,13 @@
   background: var(--color-accent-teal);
   color: var(--color-text-inverse);
 }
+.fuc-view-btn:focus-visible, .fuc-fab:focus-visible {
+  outline: 2px solid var(--color-accent-teal);
+  outline-offset: 2px;
+}
+.fuc-view-btn:active, .fuc-fab:active {
+  transform: scale(0.95);
+}
 
 .fuc-fab {
   position: fixed; bottom: 28px; right: 28px; z-index: 8000;
@@ -2970,8 +2977,8 @@ nav{position:fixed;top:0;left:0;right:0;z-index:100;background:var(--surface);ba
         <button class="btn btn-ghost btn-sm" onclick="exportFUCPDF()"><i class="fas fa-file-pdf"></i> Export</button>
         
         <div class="fuc-view-toggle">
-          <button class="fuc-view-btn active" id="fuc-view-board" onclick="setFUCView('board')" title="Board View"><i class="fas fa-columns"></i></button>
-          <button class="fuc-view-btn" id="fuc-view-list" onclick="setFUCView('list')" title="List View"><i class="fas fa-list"></i></button>
+          <button class="fuc-view-btn active" id="fuc-view-board" onclick="setFUCView('board')" title="Board View" aria-label="Switch to Board View"><i class="fas fa-columns"></i></button>
+          <button class="fuc-view-btn" id="fuc-view-list" onclick="setFUCView('list')" title="List View" aria-label="Switch to List View"><i class="fas fa-list"></i></button>
         </div>
       </div>
 
@@ -13325,6 +13332,12 @@ function setupFUCListeners() {
       document.getElementById('quickNotePopover').style.display = 'none';
       document.getElementById('fuc-fab-menu').classList.remove('open');
     }
+    if (e.key === 'Enter' || e.key === ' ') {
+      if (document.activeElement.classList.contains('quick-note-swatch')) {
+        e.preventDefault();
+        document.activeElement.click();
+      }
+    }
   });
 }
 
@@ -13352,12 +13365,12 @@ async function refreshUI() {
 <!-- QUICK NOTE POPOVER -->
 <div id="quickNotePopover" class="quick-note-popover">
   <div class="quick-note-color-row">
-    <div class="quick-note-swatch active" data-color="yellow" style="background: var(--note-yellow);" onclick="setQuickNoteColor('yellow', this)"></div>
-    <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setQuickNoteColor('teal', this)"></div>
-    <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setQuickNoteColor('purple', this)"></div>
-    <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setQuickNoteColor('red', this)"></div>
-    <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setQuickNoteColor('blue', this)"></div>
-    <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setQuickNoteColor('green', this)"></div>
+    <div class="quick-note-swatch active" data-color="yellow" role="button" tabindex="0" aria-label="Select yellow color" style="background: var(--note-yellow);" onclick="setQuickNoteColor('yellow', this)"></div>
+    <div class="quick-note-swatch" data-color="teal" role="button" tabindex="0" aria-label="Select teal color" style="background: var(--note-teal);" onclick="setQuickNoteColor('teal', this)"></div>
+    <div class="quick-note-swatch" data-color="purple" role="button" tabindex="0" aria-label="Select purple color" style="background: var(--note-purple);" onclick="setQuickNoteColor('purple', this)"></div>
+    <div class="quick-note-swatch" data-color="red" role="button" tabindex="0" aria-label="Select red color" style="background: var(--note-red);" onclick="setQuickNoteColor('red', this)"></div>
+    <div class="quick-note-swatch" data-color="blue" role="button" tabindex="0" aria-label="Select blue color" style="background: var(--note-blue);" onclick="setQuickNoteColor('blue', this)"></div>
+    <div class="quick-note-swatch" data-color="green" role="button" tabindex="0" aria-label="Select green color" style="background: var(--note-green);" onclick="setQuickNoteColor('green', this)"></div>
   </div>
   <textarea id="quick-note-text" class="quick-note-textarea" placeholder="Type your note here..."></textarea>
   <button class="quick-note-save" onclick="saveQuickNote()">Save Note</button>
@@ -13374,12 +13387,12 @@ async function refreshUI() {
     
     <div class="reminder-modal-body">
       <div class="quick-note-color-row" style="margin-bottom: var(--space-5);">
-        <div class="quick-note-swatch" data-color="yellow" style="background: var(--note-yellow);" onclick="setNoteDetailColor('yellow', this)"></div>
-        <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setNoteDetailColor('teal', this)"></div>
-        <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setNoteDetailColor('purple', this)"></div>
-        <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setNoteDetailColor('red', this)"></div>
-        <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setNoteDetailColor('blue', this)"></div>
-        <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setNoteDetailColor('green', this)"></div>
+        <div class="quick-note-swatch" data-color="yellow" role="button" tabindex="0" aria-label="Select yellow color" style="background: var(--note-yellow);" onclick="setNoteDetailColor('yellow', this)"></div>
+        <div class="quick-note-swatch" data-color="teal" role="button" tabindex="0" aria-label="Select teal color" style="background: var(--note-teal);" onclick="setNoteDetailColor('teal', this)"></div>
+        <div class="quick-note-swatch" data-color="purple" role="button" tabindex="0" aria-label="Select purple color" style="background: var(--note-purple);" onclick="setNoteDetailColor('purple', this)"></div>
+        <div class="quick-note-swatch" data-color="red" role="button" tabindex="0" aria-label="Select red color" style="background: var(--note-red);" onclick="setNoteDetailColor('red', this)"></div>
+        <div class="quick-note-swatch" data-color="blue" role="button" tabindex="0" aria-label="Select blue color" style="background: var(--note-blue);" onclick="setNoteDetailColor('blue', this)"></div>
+        <div class="quick-note-swatch" data-color="green" role="button" tabindex="0" aria-label="Select green color" style="background: var(--note-green);" onclick="setNoteDetailColor('green', this)"></div>
         <div style="flex:1"></div>
         <div class="reminder-toggle" onclick="toggleNotePin()">
           <input type="checkbox" id="note-pin-check" style="display:none">
@@ -13442,7 +13455,7 @@ async function refreshUI() {
 </div>
 
 <!-- FUC FAB -->
-<button class="fuc-fab" id="fuc-fab" style="display:none;" onclick="toggleFUCFabMenu()" title="Add New">
+<button class="fuc-fab" id="fuc-fab" style="display:none;" onclick="toggleFUCFabMenu()" title="Add New" aria-label="Open New Note or Reminder Menu">
   <i class="fas fa-plus"></i>
 </button>
 <div class="fuc-fab-menu" id="fuc-fab-menu">


### PR DESCRIPTION
I've implemented a series of micro-UX enhancements focused on accessibility and interaction feedback within the Follow-Up Center. 

Key changes include:
- **Keyboard-Accessible Color Swatches**: Note color swatches are now fully navigable via keyboard. I added `role="button"`, `tabindex="0"`, and `aria-label` attributes, and implemented a global listener for 'Enter' and 'Space' keys.
- **Improved Focus Feedback**: Added explicit `:focus-visible` styles and a tactile `:active` scale transform to the Board/List view buttons and the Floating Action Button.
- **Enhanced Screen Reader Support**: Added `aria-label` attributes to all icon-only buttons in the Follow-Up Center.
- **Syntax Validation**: Confirmed the integrity of the updated `index.html` script block.

These small touches ensure the interface is more intuitive and accessible for all users.

---
*PR created automatically by Jules for task [8632902356195469088](https://jules.google.com/task/8632902356195469088) started by @AhmetNasan*

## Summary by Sourcery

Improve accessibility and interaction feedback in the Follow-Up Center’s note palette and view controls.

New Features:
- Enable keyboard activation of quick note color swatches via Enter/Space keys mapped to click events.

Enhancements:
- Add focus-visible outlines and active-press scaling to Follow-Up Center view toggle buttons and the floating action button for clearer interaction feedback.
- Provide descriptive aria-labels for Board/List view toggle buttons and the Follow-Up Center floating action button to support screen readers.
- Document the accessible color swatch pattern and keyboard interaction approach in the Jules palette notes.

Documentation:
- Add a Jules palette note describing the accessible color swatch pattern and required ARIA/keyboard handling in the Follow-Up Center.