### PR TITLE
🎨 Palette: Improve accessibility of color swatches

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's UX Journal
+
+## 2025-05-15 - [Initial Entry]
+**Learning:** Initializing Palette's journal for UX and accessibility enhancements in QBC Operations Center.
+**Action:** Always check this journal before starting new micro-UX tasks.

--- a/index.html
+++ b/index.html
@@ -418,9 +418,14 @@
 .quick-note-swatch {
   width: 22px; height: 22px; border-radius: 50%;
   cursor: pointer; border: 2px solid transparent;
-  transition: border-color var(--transition-fast);
+  transition: all var(--transition-fast);
 }
 .quick-note-swatch.active { border-color: white; }
+.quick-note-swatch:focus-visible {
+  outline: 2px solid var(--color-accent-teal);
+  outline-offset: 2px;
+  transform: scale(1.1);
+}
 .quick-note-textarea {
   width: 100%; min-height: 100px; resize: none;
   background: var(--color-bg-input);
@@ -13322,6 +13327,10 @@ function setupFUCListeners() {
         // Pin/unpin logic for "focused" card could be complex, 
         // let's skip for now or implement if there's a clear 'focus'
       }
+      if ((e.key === 'Enter' || e.key === ' ') && e.target.classList.contains('quick-note-swatch')) {
+        e.preventDefault();
+        e.target.click();
+      }
     }
     if (e.key === 'Escape') {
       closeNoteDetailModal();
@@ -13355,12 +13364,12 @@ async function refreshUI() {
 <!-- QUICK NOTE POPOVER -->
 <div id="quickNotePopover" class="quick-note-popover">
   <div class="quick-note-color-row">
-    <div class="quick-note-swatch active" data-color="yellow" style="background: var(--note-yellow);" onclick="setQuickNoteColor('yellow', this)"></div>
-    <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setQuickNoteColor('teal', this)"></div>
-    <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setQuickNoteColor('purple', this)"></div>
-    <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setQuickNoteColor('red', this)"></div>
-    <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setQuickNoteColor('blue', this)"></div>
-    <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setQuickNoteColor('green', this)"></div>
+    <div class="quick-note-swatch active" data-color="yellow" style="background: var(--note-yellow);" onclick="setQuickNoteColor('yellow', this)" role="button" tabindex="0" aria-label="Select yellow color"></div>
+    <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setQuickNoteColor('teal', this)" role="button" tabindex="0" aria-label="Select teal color"></div>
+    <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setQuickNoteColor('purple', this)" role="button" tabindex="0" aria-label="Select purple color"></div>
+    <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setQuickNoteColor('red', this)" role="button" tabindex="0" aria-label="Select red color"></div>
+    <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setQuickNoteColor('blue', this)" role="button" tabindex="0" aria-label="Select blue color"></div>
+    <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setQuickNoteColor('green', this)" role="button" tabindex="0" aria-label="Select green color"></div>
   </div>
   <textarea id="quick-note-text" class="quick-note-textarea" placeholder="Type your note here..."></textarea>
   <button class="quick-note-save" onclick="saveQuickNote()">Save Note</button>
@@ -13377,12 +13386,12 @@ async function refreshUI() {
     
     <div class="reminder-modal-body">
       <div class="quick-note-color-row" style="margin-bottom: var(--space-5);">
-        <div class="quick-note-swatch" data-color="yellow" style="background: var(--note-yellow);" onclick="setNoteDetailColor('yellow', this)"></div>
-        <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setNoteDetailColor('teal', this)"></div>
-        <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setNoteDetailColor('purple', this)"></div>
-        <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setNoteDetailColor('red', this)"></div>
-        <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setNoteDetailColor('blue', this)"></div>
-        <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setNoteDetailColor('green', this)"></div>
+        <div class="quick-note-swatch" data-color="yellow" style="background: var(--note-yellow);" onclick="setNoteDetailColor('yellow', this)" role="button" tabindex="0" aria-label="Select yellow color"></div>
+        <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setNoteDetailColor('teal', this)" role="button" tabindex="0" aria-label="Select teal color"></div>
+        <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setNoteDetailColor('purple', this)" role="button" tabindex="0" aria-label="Select purple color"></div>
+        <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setNoteDetailColor('red', this)" role="button" tabindex="0" aria-label="Select red color"></div>
+        <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setNoteDetailColor('blue', this)" role="button" tabindex="0" aria-label="Select blue color"></div>
+        <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setNoteDetailColor('green', this)" role="button" tabindex="0" aria-label="Select green color"></div>
         <div style="flex:1"></div>
         <div class="reminder-toggle" onclick="toggleNotePin()">
           <input type="checkbox" id="note-pin-check" style="display:none">


### PR DESCRIPTION
💡 What: Added ARIA roles, tabindex, and keyboard support to "Quick Note" color swatches.
🎯 Why: Swatches were previously inaccessible to screen readers and keyboard-only users.
📸 Before/After: Added focus-visible outline and scale effect.
♿ Accessibility: Full keyboard navigation and ARIA support implemented.

---
*PR created automatically by Jules for task [1044456808893681381](https://jules.google.com/task/1044456808893681381) started by @AhmetNasan*

## Summary by Sourcery

Improve accessibility and keyboard interaction for Quick Note color swatches and document ongoing UX/accessibility work in Palette.

New Features:
- Enable keyboard activation of Quick Note color swatches via Enter and Space keys.
- Make Quick Note color swatches focusable interactive elements with ARIA button roles and descriptive labels.

Enhancements:
- Add focus-visible outline and subtle scale transition to Quick Note color swatches for clearer focus indication.

Documentation:
- Introduce Palette UX journal markdown file to capture UX and accessibility enhancements going forward.