### PR TITLE
🎨 Palette: Enhance color swatch accessibility and keyboard support

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Keyboard Accessibility for Custom Components]
+**Learning:** In a legacy or non-semantic codebase where `div` elements are used as buttons, adding `role="button"`, `tabindex="0"`, and `aria-label` is necessary but not sufficient. A global keyboard listener must be implemented to handle `Enter` and `Space` keys to trigger the `click()` event, as `div` elements do not natively support these for interaction.
+**Action:** Always implement a global `keydown` listener when retrofitting accessibility to non-semantic interactive elements. Use targeted selectors (like `DIV[role="button"]`) to avoid global side effects.

--- a/index.html
+++ b/index.html
@@ -418,9 +418,14 @@
 .quick-note-swatch {
   width: 22px; height: 22px; border-radius: 50%;
   cursor: pointer; border: 2px solid transparent;
-  transition: border-color var(--transition-fast);
+  transition: all var(--transition-fast);
 }
 .quick-note-swatch.active { border-color: white; }
+.quick-note-swatch:focus-visible {
+  outline: 2px solid var(--color-accent-teal);
+  outline-offset: 2px;
+  transform: scale(1.15);
+}
 .quick-note-textarea {
   width: 100%; min-height: 100px; resize: none;
   background: var(--color-bg-input);
@@ -13299,6 +13304,14 @@ async function exportFUCPDF() {
 
 function setupFUCListeners() {
   window.addEventListener('keydown', e => {
+    // Keyboard support for custom buttons (role="button")
+    if ((e.key === 'Enter' || e.key === ' ') &&
+        document.activeElement.getAttribute('role') === 'button' &&
+        document.activeElement.tagName === 'DIV') {
+      e.preventDefault();
+      document.activeElement.click();
+    }
+
     if (document.getElementById('page-followup').classList.contains('active')) {
       if (e.key === 'n' || e.key === 'N') {
         if (document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
@@ -13355,12 +13368,12 @@ async function refreshUI() {
 <!-- QUICK NOTE POPOVER -->
 <div id="quickNotePopover" class="quick-note-popover">
   <div class="quick-note-color-row">
-    <div class="quick-note-swatch active" data-color="yellow" style="background: var(--note-yellow);" onclick="setQuickNoteColor('yellow', this)"></div>
-    <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setQuickNoteColor('teal', this)"></div>
-    <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setQuickNoteColor('purple', this)"></div>
-    <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setQuickNoteColor('red', this)"></div>
-    <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setQuickNoteColor('blue', this)"></div>
-    <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setQuickNoteColor('green', this)"></div>
+    <div class="quick-note-swatch active" data-color="yellow" role="button" tabindex="0" aria-label="Set note color to yellow" style="background: var(--note-yellow);" onclick="setQuickNoteColor('yellow', this)"></div>
+    <div class="quick-note-swatch" data-color="teal" role="button" tabindex="0" aria-label="Set note color to teal" style="background: var(--note-teal);" onclick="setQuickNoteColor('teal', this)"></div>
+    <div class="quick-note-swatch" data-color="purple" role="button" tabindex="0" aria-label="Set note color to purple" style="background: var(--note-purple);" onclick="setQuickNoteColor('purple', this)"></div>
+    <div class="quick-note-swatch" data-color="red" role="button" tabindex="0" aria-label="Set note color to red" style="background: var(--note-red);" onclick="setQuickNoteColor('red', this)"></div>
+    <div class="quick-note-swatch" data-color="blue" role="button" tabindex="0" aria-label="Set note color to blue" style="background: var(--note-blue);" onclick="setQuickNoteColor('blue', this)"></div>
+    <div class="quick-note-swatch" data-color="green" role="button" tabindex="0" aria-label="Set note color to green" style="background: var(--note-green);" onclick="setQuickNoteColor('green', this)"></div>
   </div>
   <textarea id="quick-note-text" class="quick-note-textarea" placeholder="Type your note here..."></textarea>
   <button class="quick-note-save" onclick="saveQuickNote()">Save Note</button>
@@ -13377,12 +13390,12 @@ async function refreshUI() {
     
     <div class="reminder-modal-body">
       <div class="quick-note-color-row" style="margin-bottom: var(--space-5);">
-        <div class="quick-note-swatch" data-color="yellow" style="background: var(--note-yellow);" onclick="setNoteDetailColor('yellow', this)"></div>
-        <div class="quick-note-swatch" data-color="teal" style="background: var(--note-teal);" onclick="setNoteDetailColor('teal', this)"></div>
-        <div class="quick-note-swatch" data-color="purple" style="background: var(--note-purple);" onclick="setNoteDetailColor('purple', this)"></div>
-        <div class="quick-note-swatch" data-color="red" style="background: var(--note-red);" onclick="setNoteDetailColor('red', this)"></div>
-        <div class="quick-note-swatch" data-color="blue" style="background: var(--note-blue);" onclick="setNoteDetailColor('blue', this)"></div>
-        <div class="quick-note-swatch" data-color="green" style="background: var(--note-green);" onclick="setNoteDetailColor('green', this)"></div>
+        <div class="quick-note-swatch" data-color="yellow" role="button" tabindex="0" aria-label="Set note color to yellow" style="background: var(--note-yellow);" onclick="setNoteDetailColor('yellow', this)"></div>
+        <div class="quick-note-swatch" data-color="teal" role="button" tabindex="0" aria-label="Set note color to teal" style="background: var(--note-teal);" onclick="setNoteDetailColor('teal', this)"></div>
+        <div class="quick-note-swatch" data-color="purple" role="button" tabindex="0" aria-label="Set note color to purple" style="background: var(--note-purple);" onclick="setNoteDetailColor('purple', this)"></div>
+        <div class="quick-note-swatch" data-color="red" role="button" tabindex="0" aria-label="Set note color to red" style="background: var(--note-red);" onclick="setNoteDetailColor('red', this)"></div>
+        <div class="quick-note-swatch" data-color="blue" role="button" tabindex="0" aria-label="Set note color to blue" style="background: var(--note-blue);" onclick="setNoteDetailColor('blue', this)"></div>
+        <div class="quick-note-swatch" data-color="green" role="button" tabindex="0" aria-label="Set note color to green" style="background: var(--note-green);" onclick="setNoteDetailColor('green', this)"></div>
         <div style="flex:1"></div>
         <div class="reminder-toggle" onclick="toggleNotePin()">
           <input type="checkbox" id="note-pin-check" style="display:none">


### PR DESCRIPTION
Implemented micro-UX improvements to the Follow-Up Center color selection interface. 

The color swatches were previously non-semantic div elements that could not be reached or operated via keyboard. This change adds proper ARIA roles, keyboard focusability, and descriptive labels. Additionally, a global keyboard listener ensures that these swatches respond to standard activation keys (Enter and Space), and new focus-visible styles provide clear visual feedback during navigation.

---
*PR created automatically by Jules for task [12571462374224023253](https://jules.google.com/task/12571462374224023253) started by @AhmetNasan*

## Summary by Sourcery

Improve accessibility and keyboard interaction for quick note color swatches in the Follow-Up Center.

New Features:
- Make quick note and note detail color swatches operable via keyboard activation keys.

Enhancements:
- Add ARIA roles, focusability, and focus-visible styling to color swatch elements for better accessibility and visual feedback.

Documentation:
- Add a Jules palette note documenting lessons and best practices for retrofitting keyboard accessibility to non-semantic interactive elements.